### PR TITLE
chore: stop version managing grpc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
     <google.api-common.version>1.9.0</google.api-common.version>
     <google.common-protos.version>1.17.0</google.common-protos.version>
     <gax.version>1.54.0</gax.version>
-    <grpc.version>1.27.2</grpc.version>
     <protobuf.version>3.10.0</protobuf.version>
     <junit.version>4.13</junit.version>
     <guava.version>28.2-android</guava.version>
@@ -86,13 +85,6 @@
 
   <dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-bom</artifactId>
-        <version>${grpc.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
       <dependency>
         <groupId>com.google.api</groupId>
         <artifactId>gax-bom</artifactId>
@@ -338,7 +330,6 @@
           </groups>
 
           <links>
-            <link>https://grpc.io/grpc-java/javadoc/</link>
             <link>https://developers.google.com/protocol-buffers/docs/reference/java/</link>
             <link>https://googleapis.dev/java/google-auth-library/latest/</link>
             <link>https://googleapis.dev/java/gax/latest/</link>


### PR DESCRIPTION
This project does not use grpc so should not be managing its version via `dependencyManagement`