### PR TITLE
test: cleanup old firewalls and networks

### DIFF
--- a/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
@@ -22,11 +22,6 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
-
-import java.io.IOException;
-import java.util.Calendar;
-import java.util.List;
-
 import com.google.cloud.Timestamp;
 import com.google.cloud.compute.v1.DiskTypeSettings;
 import com.google.cloud.compute.v1.Firewall;
@@ -49,6 +44,9 @@ import com.google.cloud.compute.v1.RegionOperationSettings;
 import com.google.cloud.compute.v1.ZoneOperationClient;
 import com.google.cloud.compute.v1.ZoneOperationSettings;
 import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.List;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 

--- a/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
@@ -22,9 +22,21 @@ import com.google.api.gax.core.FixedCredentialsProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
+
+import java.io.IOException;
+import java.util.Calendar;
+import java.util.List;
+
+import com.google.cloud.Timestamp;
 import com.google.cloud.compute.v1.DiskTypeSettings;
+import com.google.cloud.compute.v1.Firewall;
+import com.google.cloud.compute.v1.FirewallClient;
+import com.google.cloud.compute.v1.FirewallSettings;
 import com.google.cloud.compute.v1.GlobalOperationClient;
 import com.google.cloud.compute.v1.GlobalOperationSettings;
+import com.google.cloud.compute.v1.Network;
+import com.google.cloud.compute.v1.NetworkClient;
+import com.google.cloud.compute.v1.NetworkSettings;
 import com.google.cloud.compute.v1.Operation;
 import com.google.cloud.compute.v1.ProjectGlobalOperationName;
 import com.google.cloud.compute.v1.ProjectName;
@@ -36,7 +48,7 @@ import com.google.cloud.compute.v1.RegionOperationClient;
 import com.google.cloud.compute.v1.RegionOperationSettings;
 import com.google.cloud.compute.v1.ZoneOperationClient;
 import com.google.cloud.compute.v1.ZoneOperationSettings;
-import java.io.IOException;
+import com.google.common.collect.Lists;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
@@ -108,5 +120,47 @@ public class BaseTest {
       fail("Operation failed: " + completedOperation.getError().toString());
     }
     return completedOperation;
+  }
+
+  static void cleanUpNetworks() throws IOException {
+    FirewallSettings firewallSettings =
+        FirewallSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
+    FirewallClient firewallClient = FirewallClient.create(firewallSettings);
+
+    NetworkSettings networkSettings =
+        NetworkSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
+    NetworkClient networkClient = NetworkClient.create(networkSettings);
+
+    // clean up resources older than 1 hour
+    Calendar calendar = Calendar.getInstance();
+    calendar.add(Calendar.HOUR_OF_DAY, -1);
+    Timestamp cutoff = Timestamp.of(calendar.getTime());
+
+    // clean up old firewalls which are used by networks
+    List<Firewall> firewalls =
+        Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
+    for (Firewall firewall : firewalls) {
+      if (firewall.getName().startsWith("test-")) {
+        Timestamp createdAt = Timestamp.parseTimestamp(firewall.getCreationTimestamp());
+        if (createdAt.compareTo(cutoff) < 0) {
+          System.out.println("deleting old firewall: " + firewall.getSelfLink());
+          waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
+        }
+      }
+    }
+
+    // clean up old networks
+    List<Network> networks =
+        Lists.newArrayList(networkClient.listNetworks("gcloud-devel").iterateAll());
+    for (Network network : networks) {
+      if (network.getName().startsWith("test-")) {
+        Timestamp createdAt = Timestamp.parseTimestamp(network.getCreationTimestamp());
+        if (createdAt.compareTo(cutoff) < 0) {
+          System.out.println(network.getSubnetworksList());
+          System.out.println("deleting old network: " + network.getSelfLink());
+          waitForOperation(networkClient.deleteNetwork(network.getSelfLink()));
+        }
+      }
+    }
   }
 }

--- a/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
@@ -154,7 +154,6 @@ public class BaseTest {
       if (network.getName().startsWith("test-")) {
         Timestamp createdAt = Timestamp.parseTimestamp(network.getCreationTimestamp());
         if (createdAt.compareTo(cutoff) < 0) {
-          System.out.println(network.getSubnetworksList());
           System.out.println("deleting old network: " + network.getSelfLink());
           waitForOperation(networkClient.deleteNetwork(network.getSelfLink()));
         }

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -88,8 +88,14 @@ public class ITFirewallTest extends BaseTest {
 
   @AfterClass
   public static void tearDown() {
-    for (String firewall : resourcesToCleanUp.get("firewall")) {
-      waitForOperation(firewallClient.deleteFirewall(firewall));
+    for (String firewallTargetLink : resourcesToCleanUp.get("firewall")) {
+      List<Firewall> firewalls =
+          Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
+      for (Firewall firewall : firewalls) {
+        if (firewall.getSelfLink().startsWith(firewallTargetLink)) {
+          waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
+        }
+      }
     }
     for (String network : resourcesToCleanUp.get("firewall-network")) {
       waitForOperation(networkClient.deleteNetwork(network));

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -100,7 +100,9 @@ public class ITFirewallTest extends BaseTest {
     for (String network : resourcesToCleanUp.get("firewall-network")) {
       waitForOperation(networkClient.deleteNetwork(network));
     }
+
     firewallClient.close();
+    networkClient.close();
   }
 
   @Test

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -118,8 +118,11 @@ public class ITFirewallTest extends BaseTest {
   public void listFirewallsTest() {
     List<Firewall> firewalls =
         Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
+
+    boolean found = false;
     for (Firewall firewall : firewalls) {
       if (FIREWALL_NAME.equals(firewall.getName())) {
+        found = true;
         assertThat(firewall.getAllowedList()).isEqualTo(ALLOWEDS);
         assertThat(firewall.getDescription()).isEqualTo(FIREWALL_DESCRIPTION);
         assertThat(firewall.getDirection()).isEqualTo(DIRECTION);
@@ -128,5 +131,6 @@ public class ITFirewallTest extends BaseTest {
         assertThat(firewall.getSelfLink()).isEqualTo(FIREWALL_LINK);
       }
     }
+    assertThat(found).isTrue();
   }
 }

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -88,9 +88,9 @@ public class ITFirewallTest extends BaseTest {
 
   @AfterClass
   public static void tearDown() {
+    List<Firewall> firewalls =
+        Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
     for (String firewallTargetLink : resourcesToCleanUp.get("firewall")) {
-      List<Firewall> firewalls =
-          Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
       for (Firewall firewall : firewalls) {
         if (firewall.getSelfLink().startsWith(firewallTargetLink)) {
           waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -57,6 +57,8 @@ public class ITFirewallTest extends BaseTest {
 
   @BeforeClass
   public static void setUp() throws IOException {
+    cleanUpNetworks();
+
     FirewallSettings firewallSettings =
         FirewallSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
     firewallClient = FirewallClient.create(firewallSettings);

--- a/src/test/java/com/google/cloud/compute/v1/it/ITNetworkTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITNetworkTest.java
@@ -38,6 +38,8 @@ public class ITNetworkTest extends BaseTest {
 
   @BeforeClass
   public static void setUp() throws IOException {
+    cleanUpNetworks();
+
     NetworkSettings networkSettings =
         NetworkSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
     networkClient = NetworkClient.create(networkSettings);

--- a/src/test/java/com/google/cloud/compute/v1/it/ITNetworkTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITNetworkTest.java
@@ -63,8 +63,14 @@ public class ITNetworkTest extends BaseTest {
   public void listNetworkTest() {
     List<Network> networks =
         Lists.newArrayList(networkClient.listNetworks(PROJECT_NAME).iterateAll());
-    assertThat(networks).isNotNull();
-    assertThat(networks.size()).isGreaterThan(0);
-    assertThat(networks.contains(null)).isFalse();
+
+    boolean found = false;
+    for (Network network : networks) {
+      if (NETWORK.equals(network.getName())) {
+        found = true;
+        assertThat(network.getAutoCreateSubnetworks()).isFalse();
+      }
+    }
+    assertThat(found).isTrue();
   }
 }

--- a/src/test/java/com/google/cloud/compute/v1/it/ITNetworkTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITNetworkTest.java
@@ -17,6 +17,9 @@ package com.google.cloud.compute.v1.it;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.cloud.compute.v1.Firewall;
+import com.google.cloud.compute.v1.FirewallClient;
+import com.google.cloud.compute.v1.FirewallSettings;
 import com.google.cloud.compute.v1.Network;
 import com.google.cloud.compute.v1.NetworkClient;
 import com.google.cloud.compute.v1.NetworkSettings;
@@ -33,12 +36,17 @@ import org.junit.Test;
 public class ITNetworkTest extends BaseTest {
   private static final String NETWORK = TestHelper.getTestUniqueName("network");;
 
+  private static FirewallClient firewallClient;
   private static NetworkClient networkClient;
   private static ListMultimap<String, String> resourcesToCleanUp = ArrayListMultimap.create();
 
   @BeforeClass
   public static void setUp() throws IOException {
     cleanUpNetworks();
+
+    FirewallSettings firewallSettings =
+        FirewallSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
+    firewallClient = FirewallClient.create(firewallSettings);
 
     NetworkSettings networkSettings =
         NetworkSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
@@ -53,9 +61,20 @@ public class ITNetworkTest extends BaseTest {
 
   @AfterClass
   public static void tearDown() {
-    for (String network : resourcesToCleanUp.get("network")) {
-      waitForOperation(networkClient.deleteNetwork(network));
+    List<Firewall> firewalls =
+        Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
+    for (String networkLink : resourcesToCleanUp.get("network")) {
+      Network network = networkClient.getNetwork(networkLink);
+      for (Firewall firewall : firewalls) {
+        if (firewall.getName().startsWith(network.getName())) {
+          System.out.println("deleting firewall:" + firewall.getSelfLink());
+          waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
+        }
+      }
+      waitForOperation(networkClient.deleteNetwork(networkLink));
     }
+
+    firewallClient.close();
     networkClient.close();
   }
 


### PR DESCRIPTION
Fixes #177

* Global quota for networks is 10. Sometimes when tests fail, extra networks (and firewalls that use them) are left over. This adds a before helper that cleans up test resources > 1 hour old.
* Creating a firewall also creates sub-firewalls. We cannot delete the network that those sub-firewalls use until we cleanup all the firewalls created. Updated the firewall cleanup to list firewalls and delete all the sub-firewalls of the one that was created for the test.