### PR TITLE
test: fix more flaky network tests

### DIFF
--- a/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
@@ -120,11 +120,30 @@ public class BaseTest {
     return completedOperation;
   }
 
-  static void cleanUpNetworks() throws IOException {
+  static void cleanUpNetwork(Network network) throws IOException {
     FirewallSettings firewallSettings =
         FirewallSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
     FirewallClient firewallClient = FirewallClient.create(firewallSettings);
 
+    // TODO: switch to firewall list filter
+    List<Firewall> firewalls =
+        Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
+    for (Firewall firewall : firewalls) {
+      if (firewall.getNetwork().equals(network.getSelfLink())) {
+        System.out.println("deleting firewall: " + firewall.getSelfLink());
+        waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
+      }
+    }
+
+    NetworkSettings networkSettings =
+        NetworkSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
+    NetworkClient networkClient = NetworkClient.create(networkSettings);
+
+    System.out.println("deleting network:" + network.getSelfLink());
+    waitForOperation(networkClient.deleteNetwork(network.getSelfLink()));
+  }
+
+  static void cleanUpNetworks() throws IOException {
     NetworkSettings networkSettings =
         NetworkSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
     NetworkClient networkClient = NetworkClient.create(networkSettings);
@@ -134,19 +153,6 @@ public class BaseTest {
     calendar.add(Calendar.HOUR_OF_DAY, -1);
     Timestamp cutoff = Timestamp.of(calendar.getTime());
 
-    // clean up old firewalls which are used by networks
-    List<Firewall> firewalls =
-        Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
-    for (Firewall firewall : firewalls) {
-      if (firewall.getName().startsWith("test-")) {
-        Timestamp createdAt = Timestamp.parseTimestamp(firewall.getCreationTimestamp());
-        if (createdAt.compareTo(cutoff) < 0) {
-          System.out.println("deleting old firewall: " + firewall.getSelfLink());
-          waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
-        }
-      }
-    }
-
     // clean up old networks
     List<Network> networks =
         Lists.newArrayList(networkClient.listNetworks(DEFAULT_PROJECT).iterateAll());
@@ -154,8 +160,7 @@ public class BaseTest {
       if (network.getName().startsWith("test-")) {
         Timestamp createdAt = Timestamp.parseTimestamp(network.getCreationTimestamp());
         if (createdAt.compareTo(cutoff) < 0) {
-          System.out.println("deleting old network: " + network.getSelfLink());
-          waitForOperation(networkClient.deleteNetwork(network.getSelfLink()));
+          cleanUpNetwork(network);
         }
       }
     }

--- a/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
@@ -130,7 +130,6 @@ public class BaseTest {
         Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
     for (Firewall firewall : firewalls) {
       if (firewall.getNetwork().equals(network.getSelfLink())) {
-        System.out.println("deleting firewall: " + firewall.getSelfLink());
         waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
       }
     }
@@ -139,7 +138,6 @@ public class BaseTest {
         NetworkSettings.newBuilder().setCredentialsProvider(credentialsProvider).build();
     NetworkClient networkClient = NetworkClient.create(networkSettings);
 
-    System.out.println("deleting network:" + network.getSelfLink());
     waitForOperation(networkClient.deleteNetwork(network.getSelfLink()));
   }
 

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -93,6 +93,7 @@ public class ITFirewallTest extends BaseTest {
     for (String firewallTargetLink : resourcesToCleanUp.get("firewall")) {
       for (Firewall firewall : firewalls) {
         if (firewall.getSelfLink().startsWith(firewallTargetLink)) {
+          System.out.println("deleting firewall:" + firewall.getSelfLink());
           waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
         }
       }

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -87,23 +87,11 @@ public class ITFirewallTest extends BaseTest {
   }
 
   @AfterClass
-  public static void tearDown() {
-    List<Firewall> firewalls =
-        Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
-
-    // clean up implicitly created firewalls - delete the firewalls for the network
-    // created in the setup block
+  public static void tearDown() throws IOException {
+    // Note: firewalls will be cleaned up by the cleanUpNetwork helper
     for (String network : resourcesToCleanUp.get("firewall-network")) {
       Network firewallNetwork = networkClient.getNetwork(network);
-      System.out.println("finding firewalls for network: " + network);
-      for (Firewall firewall : firewalls) {
-        if (firewall.getNetwork().equals(firewallNetwork.getSelfLink())) {
-          System.out.println("deleting firewall: " + firewall.getSelfLink());
-          waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
-        }
-      }
-      System.out.println("deleting network: " + network);
-      waitForOperation(networkClient.deleteNetwork(network));
+      cleanUpNetwork(firewallNetwork);
     }
 
     firewallClient.close();

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -92,6 +92,7 @@ public class ITFirewallTest extends BaseTest {
         Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
     for (String firewallTargetLink : resourcesToCleanUp.get("firewall")) {
       for (Firewall firewall : firewalls) {
+        System.out.println("candidate firewall: " + firewall.getSelfLink());
         if (firewall.getSelfLink().startsWith(firewallTargetLink)) {
           System.out.println("deleting firewall:" + firewall.getSelfLink());
           waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -91,8 +91,10 @@ public class ITFirewallTest extends BaseTest {
     List<Firewall> firewalls =
         Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
     for (String firewallTargetLink : resourcesToCleanUp.get("firewall")) {
+      Firewall mainFirewall = firewallClient.getFirewall(firewallTargetLink);
+      System.out.println(mainFirewall);
       for (Firewall firewall : firewalls) {
-        System.out.println("candidate firewall: " + firewall.getSelfLink());
+        System.out.println(firewall);
         if (firewall.getSelfLink().startsWith(firewallTargetLink)) {
           System.out.println("deleting firewall:" + firewall.getSelfLink());
           waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));

--- a/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITFirewallTest.java
@@ -90,18 +90,19 @@ public class ITFirewallTest extends BaseTest {
   public static void tearDown() {
     List<Firewall> firewalls =
         Lists.newArrayList(firewallClient.listFirewalls(PROJECT_NAME).iterateAll());
-    for (String firewallTargetLink : resourcesToCleanUp.get("firewall")) {
-      Firewall mainFirewall = firewallClient.getFirewall(firewallTargetLink);
-      System.out.println(mainFirewall);
+
+    // clean up implicitly created firewalls - delete the firewalls for the network
+    // created in the setup block
+    for (String network : resourcesToCleanUp.get("firewall-network")) {
+      Network firewallNetwork = networkClient.getNetwork(network);
+      System.out.println("finding firewalls for network: " + network);
       for (Firewall firewall : firewalls) {
-        System.out.println(firewall);
-        if (firewall.getSelfLink().startsWith(firewallTargetLink)) {
-          System.out.println("deleting firewall:" + firewall.getSelfLink());
+        if (firewall.getNetwork().equals(firewallNetwork.getSelfLink())) {
+          System.out.println("deleting firewall: " + firewall.getSelfLink());
           waitForOperation(firewallClient.deleteFirewall(firewall.getSelfLink()));
         }
       }
-    }
-    for (String network : resourcesToCleanUp.get("firewall-network")) {
+      System.out.println("deleting network: " + network);
       waitForOperation(networkClient.deleteNetwork(network));
     }
 


### PR DESCRIPTION
Turns out we're racing against internal rules that are creating firewall rules for network interfaces. This PR uses a helper to clean up network interfaces by first deleting all firewalls associated with that network, then deleting the network.

Fixes #168 