### PR TITLE
test: deflake and allow other projects to run TI tests

### DIFF
--- a/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/BaseTest.java
@@ -149,7 +149,7 @@ public class BaseTest {
 
     // clean up old networks
     List<Network> networks =
-        Lists.newArrayList(networkClient.listNetworks("gcloud-devel").iterateAll());
+        Lists.newArrayList(networkClient.listNetworks(DEFAULT_PROJECT).iterateAll());
     for (Network network : networks) {
       if (network.getName().startsWith("test-")) {
         Timestamp createdAt = Timestamp.parseTimestamp(network.getCreationTimestamp());

--- a/src/test/java/com/google/cloud/compute/v1/it/ITTargetPoolTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITTargetPoolTest.java
@@ -163,7 +163,7 @@ public class ITTargetPoolTest extends BaseTest {
     Operation response =
         targetPoolClient.addHealthCheckTargetPool(
             REGION_TARGET_POOL_NAME, targetPoolsAddHealthCheckRequestResource);
-    response = waitForOperation(response)
+    response = waitForOperation(response);
     assertThat(response).isNotNull();
     assertThat(response.getOperationType()).isEqualTo("AddHealthCheck");
     assertThat(response.getStatus()).isEqualTo("DONE");

--- a/src/test/java/com/google/cloud/compute/v1/it/ITTargetPoolTest.java
+++ b/src/test/java/com/google/cloud/compute/v1/it/ITTargetPoolTest.java
@@ -133,6 +133,7 @@ public class ITTargetPoolTest extends BaseTest {
     assertThat(response.getStatus()).isEqualTo("RUNNING");
     assertThat(response.getRegion()).isEqualTo(REGION_LINK);
     assertThat(response.getTargetLink()).isEqualTo(TARGET_POOL_SELF_LINK);
+    waitForOperation(response);
   }
 
   @Test
@@ -162,6 +163,7 @@ public class ITTargetPoolTest extends BaseTest {
     Operation response =
         targetPoolClient.addHealthCheckTargetPool(
             REGION_TARGET_POOL_NAME, targetPoolsAddHealthCheckRequestResource);
+    response = waitForOperation(response)
     assertThat(response).isNotNull();
     assertThat(response.getOperationType()).isEqualTo("AddHealthCheck");
     assertThat(response.getStatus()).isEqualTo("DONE");


### PR DESCRIPTION
Update TI cleanup code to clean up target project instead of "gcloud-devel". I also deflaked the TargetPool testsby waiting for LORs to complete before cleanup. 

Fixes #194 ☕️
