### PR TITLE
Release java-compute v1.0.0-alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,17 @@ If you are using Maven without BOM, add this to your dependencies:
 <dependency>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-compute</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>1.0.0-alpha</version>
 </dependency>
 ```
 
 If you are using Gradle, add this to your dependencies
 ```Groovy
-compile 'com.google.cloud:google-cloud-compute:0.0.1-SNAPSHOT'
+compile 'com.google.cloud:google-cloud-compute:1.0.0-alpha'
 ```
 If you are using SBT, add this to your dependencies
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-compute" % "0.0.1-SNAPSHOT"
+libraryDependencies += "com.google.cloud" % "google-cloud-compute" % "1.0.0-alpha"
 ```
 [//]: # ({x-version-update-end})
 

--- a/google-cloud-compute-bom/pom.xml
+++ b/google-cloud-compute-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-compute-bom</artifactId>
-  <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+  <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -68,12 +68,12 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-compute</artifactId>
-        <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+        <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-compute-v1</artifactId>
-        <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
+        <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-compute/pom.xml
+++ b/google-cloud-compute/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-compute</artifactId>
-  <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+  <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
   <packaging>jar</packaging>
   <name>Google Compute Engine</name>
   <url>https://github.com/googleapis/java-compute</url>
@@ -11,7 +11,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-compute-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+    <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-compute</site.installationModule>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-compute-parent</artifactId>
   <packaging>pom</packaging>
-  <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+  <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
   <name>Google Compute Engine Parent</name>
   <url>https://github.com/googleapis/java-compute</url>
   <description>
@@ -70,12 +70,12 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-compute</artifactId>
-        <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+        <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-compute-v1</artifactId>
-        <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
+        <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
       </dependency>
 
       <dependency>

--- a/proto-google-cloud-compute-v1/pom.xml
+++ b/proto-google-cloud-compute-v1/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-compute-v1</artifactId>
-  <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
+  <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
   <name>proto-google-cloud-compute-v1</name>
   <description>Proto library for google-cloud-compute</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-compute-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+    <version>1.0.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-compute:0.0.0:0.0.1-SNAPSHOT
-proto-google-cloud-compute-v1:0.0.0:0.0.1-SNAPSHOT
-grpc-google-cloud-compute-v1:0.0.0:0.0.1-SNAPSHOT
+google-cloud-compute:1.0.0-alpha:1.0.1-alpha-SNAPSHOT
+proto-google-cloud-compute-v1:1.0.0-alpha:1.0.1-alpha-SNAPSHOT
+grpc-google-cloud-compute-v1:1.0.0-alpha:1.0.1-alpha-SNAPSHOT


### PR DESCRIPTION
This pull request was generated using releasetool.

01-07-2021 13:06 PST

- chore: Update README.md
- chore: Update README.md
- feat!: Java Compute DIREGAPIC initial commit

### Implementation Changes

### New Features

### Dependencies

### Documentation

### Internal / Testing Changes