### PR TITLE
chore: Update google-cloud-shared-dependencies dependency to 1.1.0

### DIFF
--- a/google-cloud-compute/pom.xml
+++ b/google-cloud-compute/pom.xml
@@ -36,12 +36,10 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
-      <version>1.63.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-httpjson</artifactId>
-      <version>0.80.3</version>
     </dependency>
     <dependency>
       <groupId>org.threeten</groupId>
@@ -72,14 +70,12 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-httpjson</artifactId>
-      <version>0.80.3</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax</artifactId>
-      <version>1.63.3</version>
       <classifier>testlib</classifier>
       <scope>test</scope>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-shared-dependencies</artifactId>
-        <version>1.0.0</version>
+        <version>1.1.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This is to make sure we depend on the proper gax (1.64.0 and 0.81.0 for httpjson)
