### PR TITLE
chore: release v1.3.0-alpha

### DIFF
--- a/google-cloud-compute-bom/pom.xml
+++ b/google-cloud-compute-bom/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-compute-bom</artifactId>
-  <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+  <version>1.3.0-alpha</version><!-- {x-version-update:google-cloud-compute:current} -->
   <packaging>pom</packaging>
   <parent>
     <groupId>com.google.cloud</groupId>
@@ -64,12 +64,12 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-compute</artifactId>
-        <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+        <version>1.3.0-alpha</version><!-- {x-version-update:google-cloud-compute:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-compute-v1</artifactId>
-        <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
+        <version>1.3.0-alpha</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/google-cloud-compute/pom.xml
+++ b/google-cloud-compute/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-compute</artifactId>
-  <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+  <version>1.3.0-alpha</version><!-- {x-version-update:google-cloud-compute:current} -->
   <packaging>jar</packaging>
   <name>Google Compute Engine</name>
   <url>https://github.com/googleapis/java-compute</url>
@@ -15,7 +15,7 @@
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-compute-parent</artifactId>
-    <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+    <version>1.3.0-alpha</version><!-- {x-version-update:google-cloud-compute:current} -->
   </parent>
   <properties>
     <site.installationModule>google-cloud-compute</site.installationModule>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.google.cloud</groupId>
   <artifactId>google-cloud-compute-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+  <version>1.3.0-alpha</version><!-- {x-version-update:google-cloud-compute:current} -->
   <name>Google Compute Engine Parent</name>
   <url>https://github.com/googleapis/java-compute</url>
   <description>
@@ -61,12 +61,12 @@
       <dependency>
         <groupId>com.google.cloud</groupId>
         <artifactId>google-cloud-compute</artifactId>
-        <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+        <version>1.3.0-alpha</version><!-- {x-version-update:google-cloud-compute:current} -->
       </dependency>
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-cloud-compute-v1</artifactId>
-        <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
+        <version>1.3.0-alpha</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
       </dependency>
 
       <dependency>

--- a/proto-google-cloud-compute-v1/pom.xml
+++ b/proto-google-cloud-compute-v1/pom.xml
@@ -4,13 +4,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.google.api.grpc</groupId>
   <artifactId>proto-google-cloud-compute-v1</artifactId>
-  <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
+  <version>1.3.0-alpha</version><!-- {x-version-update:proto-google-cloud-compute-v1:current} -->
   <name>proto-google-cloud-compute-v1</name>
   <description>Proto library for google-cloud-compute</description>
   <parent>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-compute-parent</artifactId>
-    <version>1.2.1-alpha-SNAPSHOT</version><!-- {x-version-update:google-cloud-compute:current} -->
+    <version>1.3.0-alpha</version><!-- {x-version-update:google-cloud-compute:current} -->
   </parent>
   <dependencies>
     <dependency>

--- a/versions.txt
+++ b/versions.txt
@@ -1,6 +1,6 @@
 # Format:
 # module:released-version:current-version
 
-google-cloud-compute:1.2.0-alpha:1.2.1-alpha-SNAPSHOT
-proto-google-cloud-compute-v1:1.2.0-alpha:1.2.1-alpha-SNAPSHOT
-grpc-google-cloud-compute-v1:1.2.0-alpha:1.2.1-alpha-SNAPSHOT
+google-cloud-compute:1.3.0-alpha:1.3.0-alpha
+proto-google-cloud-compute-v1:1.3.0-alpha:1.3.0-alpha
+grpc-google-cloud-compute-v1:1.3.0-alpha:1.3.0-alpha


### PR DESCRIPTION
This pull request was generated using releasetool.

07-07-2021 10:32 PDT

### Dependencies
- update dependency com.google.cloud:google-cloud-shared-dependencies to v1.4.0 ([#475](https://www.github.com/googleapis/java-compute/issues/475)) ([0a7f7d1](https://www.github.com/googleapis/java-compute/commit/0a7f7d1044972ca5b922bb43f79b70766583f50d))
- update dependency com.google.cloud:google-cloud-shared-dependencies to v1.3.0 ([#455](https://www.github.com/googleapis/java-compute/issues/455)) ([2a9b955](https://www.github.com/googleapis/java-compute/commit/2a9b9558150be14e3caab7559656074f044cc9b4))

### Bug Fixes
- regenerate compute.proto with uint64/int64 field types where appropriate (instead of string) ([#477](https://www.github.com/googleapis/java-compute/issues/477)) ([130782d](https://www.github.com/googleapis/java-compute/commit/130782d38e86af697cd6f1578dcdc846de5dcfb5))
- Update dependencies.sh to not break on mac ([#466](https://www.github.com/googleapis/java-compute/issues/466)) ([ed797d3](https://www.github.com/googleapis/java-compute/commit/ed797d3ba8635afb75020faefd71899aeeaba2d1))
- Add shopt -s nullglob to dependencies script ([#478](https://www.github.com/googleapis/java-compute/issues/478)) ([f6a3200](https://www.github.com/googleapis/java-compute/commit/f6a32008be1613dc10e7202c185d1ea45e147c1d))

### Implementation Changes
- Migrate to gapic-generator-java, remove monolith dependency (#476)