### PR TITLE
fix(java): exclude unused dependencies from gax-grpc

### DIFF
--- a/google-cloud-compute/pom.xml
+++ b/google-cloud-compute/pom.xml
@@ -37,7 +37,8 @@
     </dependency>
 
     <!-- gax-grpc brings in Protobuf reflection configurations which are needed
-    for native image compilation. -->
+    for native image compilation. Excluding gax-grpc dependencies since they are not
+    needed for standard Java and native-image users.  -->
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
@@ -93,6 +94,14 @@
         <exclusion>
           <groupId>io.grpc</groupId>
           <artifactId>grpc-netty-shaded</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-googleapis</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/google-cloud-compute/pom.xml
+++ b/google-cloud-compute/pom.xml
@@ -41,6 +41,60 @@
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-grpc</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.api</groupId>
+          <artifactId>api-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.api</groupId>
+          <artifactId>api-common</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.api.grpc</groupId>
+          <artifactId>proto-google-common-protos</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.auth</groupId>
+          <artifactId>google-auth-library-credentials</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.guava</groupId>
+          <artifactId>guava</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.threeten</groupId>
+          <artifactId>threetenbp</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.auth</groupId>
+          <artifactId>google-auth-library-oauth2-http</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-alts</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-auth</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-protobuf</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-stub</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.grpc</groupId>
+          <artifactId>grpc-netty-shaded</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Gax-grpc contains some native-image configurations that are needed for native-image compilation to be successful (see https://github.com/googleapis/java-compute/pull/688). However, adding the gax-grpc dependency also transitively brings in it's own dependencies which are not required for either standard Java or native image users. This can result in some side effects including the one seen in https://github.com/googleapis/gax-java/issues/1781. This PR excludes those dependencies to ensure that only the necessary code is brought in. 

Reproducer: https://github.com/mpeddada1/test-gax/tree/main